### PR TITLE
chore: remove duplicate and incorrect 'repository' field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,10 +63,6 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/Stanko/react-plx.git"
-  },
   "keywords": [
     "react",
     "react-component",


### PR DESCRIPTION
should fix `npm repo react-animate-height` opening the wrong repo when used