### PR TITLE
Changes Object.assign in component to spread op

### DIFF
--- a/source/AnimateHeight.js
+++ b/source/AnimateHeight.js
@@ -63,7 +63,7 @@ const AnimateHeight = class extends React.Component {
       overflow = 'hidden';
     }
 
-    this.animationStateClasses = Object.assign(ANIMATION_STATE_CLASSES, props.animationStateClasses);
+    this.animationStateClasses = { ...ANIMATION_STATE_CLASSES, ...props.animationStateClasses };
 
     const animationStateClasses = this.getStaticStateClasses(height);
 


### PR DESCRIPTION
This should allow the code to build with the polyfill and work in IE11. Currently, it errors on this line.