### PR TITLE
Implement CSS transition delays

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -11,6 +11,7 @@ const Example = class extends React.Component {
     this.state = {
       height: 0,
       height2: 'auto',
+      height3: 0,
     };
   }
 
@@ -18,6 +19,8 @@ const Example = class extends React.Component {
     const {
       height,
       height2,
+      height3,
+      delay,
     } = this.state;
 
     return (
@@ -128,7 +131,7 @@ const Example = class extends React.Component {
             100% (of the parent height)
           </button>
         </div>
-        <div style={ { height: 800 } }>
+        <div>
           <AnimateHeight
             height={ height2 }
             duration={ 500 }
@@ -182,6 +185,98 @@ const Example = class extends React.Component {
             </div>
           </AnimateHeight>
         </div>
+
+        <h3>Demo, with transition delay</h3>
+        <p>
+          Current Height: <b>{ height3 }</b><br/>
+          Current Delay: <b>{ delay }</b>
+        </p>
+        <p>Set delay to:</p>
+        <div className='buttons'>
+          <button className='btn btn-sm' onClick={ () => this.setState({ delay: 0 }) }>
+            0
+          </button>
+          <button className='btn btn-sm' onClick={ () => this.setState({ delay: 300 }) }>
+            300
+          </button>
+          <button className='btn btn-sm' onClick={ () => this.setState({ delay: 600 }) }>
+            600
+          </button>
+          <button className='btn btn-sm' onClick={ () => this.setState({ delay: 1000 }) }>
+            1000
+          </button>
+        </div>
+        <p className=''>Set height to:</p>
+        <div className='buttons'>
+          <button className='btn btn-sm' onClick={ () => this.setState({ height3: 0 }) }>
+            0
+          </button>
+          <button className='btn btn-sm' onClick={ () => this.setState({ height3: 100 }) }>
+            100
+          </button>
+          <button className='btn btn-sm' onClick={ () => this.setState({ height3: 200 }) }>
+            200
+          </button>
+          <button className='btn btn-sm' onClick={ () => this.setState({ height3: 300 }) }>
+            300
+          </button>
+          <button className='btn btn-sm' onClick={ () => this.setState({ height3: 'auto' }) }>
+            auto
+          </button>
+        </div>
+        <AnimateHeight
+          height={ height3 }
+          delay={delay}
+          duration={ 500 }
+          onAnimationEnd={ () => { console.log('React Animate Height - animation ended'); } }
+          onAnimationStart={ () => { console.log('React Animate Height - animation started'); } }
+          className='demo demo-3'
+          animateOpacity
+        >
+          <div className='demo-content'>
+            <p>
+              It looked serious, but we in California, like everywhere else, were
+              not alarmed. We were sure that the bacteriologists would find a way to
+              overcome this new germ, just as they had overcome other germs in the
+              past. But the trouble was the astonishing quickness with which this germ
+              destroyed human beings, and the fact that it inevitably killed any
+              human body it entered. No one ever recovered. There was the old Asiatic
+              cholera, when you might eat dinner with a well man in the evening, and
+              the next morning, if you got up early enough, you would see him being
+              hauled by your window in the death-cart. But this new plague was quicker
+              than that&mdash;much quicker.
+            </p>
+            <input
+              className='form-control'
+              type='text'
+              placeholder='Test for focus'
+              onFocus={ () => console.log('Input 2 focused') }
+            />
+            <p>
+              From the moment of the first signs of it, a man would be dead in an
+              hour. Some lasted for several hours. Many died within ten or fifteen
+              minutes of the appearance of the first signs.
+            </p>
+            <p>
+              The heart began to beat faster and the heat of the body to increase.
+              Then came the scarlet rash, spreading like wildfire over the face and
+              body. Most persons never noticed the increase in heat and heart-beat,
+              and the first they knew was when the scarlet rash came out. Usually,
+              they had convulsions at the time of the appearance of the rash. But
+              these convulsions did not last long and were not very severe. If one
+              lived through them, he became perfectly quiet, and only did he feel a
+              numbness swiftly creeping up his body from the feet. The heels became
+              numb first, then the legs, and hips, and when the numbness reached
+              as high as his heart he died. They did not rave or sleep. Their minds
+              always remained cool and calm up to the moment their heart numbed and
+              stopped. And another strange thing was the rapidity of decomposition. No
+              sooner was a person dead than the body seemed to fall to pieces, to
+              fly apart, to melt away even as you looked at it. That was one of the
+              reasons the plague spread so rapidly. All the billions of germs in a
+              corpse were so immediately released.
+            </p>
+          </div>
+        </AnimateHeight>
       </div>
     );
   }

--- a/docs/docs.scss
+++ b/docs/docs.scss
@@ -58,8 +58,8 @@ h2, h3, h4 {
   background: #fff;
 }
 
-.demo-2 {
-  margin-bottom: 100px;
+.demo-3 {
+  margin-bottom: 300px;
 
   .demo-content {
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-animate-height",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/source/AnimateHeight.js
+++ b/source/AnimateHeight.js
@@ -102,6 +102,9 @@ const AnimateHeight = class extends React.Component {
       const contentHeight = this.contentElement.offsetHeight;
       this.contentElement.style.overflow = '';
 
+      // set total animation time
+      const totalDuration = nextProps.duration + nextProps.delay;
+
       let newHeight = null;
       const timeoutState = {
         height: null, // it will be always set to either 'auto' or specific number
@@ -190,7 +193,7 @@ const AnimateHeight = class extends React.Component {
           this.hideContent(timeoutState.height);
           // Run a callback if it exists
           this.runCallback(nextProps.onAnimationEnd);
-        }, nextProps.duration);
+        }, totalDuration);
       } else {
         // ANIMATION STARTS, run a callback if it exists
         this.runCallback(nextProps.onAnimationStart);
@@ -207,7 +210,7 @@ const AnimateHeight = class extends React.Component {
           this.hideContent(newHeight);
           // Run a callback if it exists
           this.runCallback(nextProps.onAnimationEnd);
-        }, nextProps.duration);
+        }, totalDuration);
       }
     }
   }
@@ -260,6 +263,7 @@ const AnimateHeight = class extends React.Component {
       contentClassName,
       duration,
       easing,
+      delay,
       style,
     } = this.props;
     const {
@@ -277,7 +281,7 @@ const AnimateHeight = class extends React.Component {
     };
 
     if (shouldUseTransitions && applyInlineTransitions) {
-      componentStyle.transition = `height ${ duration }ms ${ easing }`;
+      componentStyle.transition = `height ${ duration }ms ${ easing } ${ delay }ms`;
 
       // Include transition passed through styles
       if (style.transition) {
@@ -291,7 +295,7 @@ const AnimateHeight = class extends React.Component {
     const contentStyle = {};
 
     if (animateOpacity) {
-      contentStyle.transition = `opacity ${ duration }ms ${ easing } `;
+      contentStyle.transition = `opacity ${ duration }ms ${ easing } ${ delay }ms`;
       // Add webkit vendor prefix still used by opera, blackberry...
       contentStyle.WebkitTransition = contentStyle.transition;
 
@@ -313,6 +317,7 @@ const AnimateHeight = class extends React.Component {
       'duration',
       'easing',
       'height',
+      'delay',
     ];
 
     return (
@@ -342,6 +347,7 @@ AnimateHeight.propTypes = {
   className: PropTypes.string,
   contentClassName: PropTypes.string,
   duration: PropTypes.number.isRequired,
+  delay: PropTypes.number.isRequired,
   easing: PropTypes.string.isRequired,
   height: PropTypes.oneOfType([
     PropTypes.string,
@@ -357,6 +363,7 @@ AnimateHeight.defaultProps = {
   animationStateClasses: ANIMATION_STATE_CLASSES,
   applyInlineTransitions: true,
   duration: 250,
+  delay: 0,
   easing: 'ease',
   style: {},
 };

--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -18,6 +18,7 @@ export interface AnimateHeightProps {
   applyInlineTransitions?: boolean;
   className?: string;
   contentClassName?: string;
+  delay?: number;
   duration?: number;
   easing?: string;
   height?: string | number;


### PR DESCRIPTION
Thanks for making this component Stanko, it's been a great way to stop relying on max height hacks. From time to time I've required a transition delay so figured I'd add the functionality.

This PR adds a `delay` prop to the component which is the time, in milliseconds, to offset the
transition animation. It applies this time to the height/opacity transition styles, and calculates the time in which to run animation callbacks by adding delay and duration together.

E.g.,
```
<AnimateHeight
    duration={500}
    delay={300}
    easing="ease-in-out"
>
  ...
```