### PR TITLE
Pass target height to start and end callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,15 @@ export default class Example extends Component {
 
 * **onAnimationStart**: function
 
-  Callback which will be called when animation starts
+  Callback which will be called when animation starts.
+
+  This first argument passed to this callback is an object containing `newHeight`, the pixel value of the height at which the animation will end.
 
 * **onAnimationEnd**: function
 
-  Callback which will be called when animation ends
+  Callback which will be called when animation ends.
+
+  This first argument passed to this callback is an object containing `newHeight`, the pixel value of the height at which the animation ended.
 
 * **applyInlineTransitions**: boolean, default: `true`
 

--- a/source/AnimateHeight.js
+++ b/source/AnimateHeight.js
@@ -68,9 +68,9 @@ function isPercentage(height) {
     isNumber(height.substr(0, height.length - 1));
 }
 
-function runCallback(callback) {
+function runCallback(callback, params) {
   if (callback && typeof callback === 'function') {
-    callback();
+    callback(params);
   }
 }
 
@@ -205,7 +205,7 @@ const AnimateHeight = class extends React.Component {
           this.setState(timeoutState);
 
           // ANIMATION STARTS, run a callback if it exists
-          runCallback(onAnimationStart);
+          runCallback(onAnimationStart, { newHeight: timeoutState.height });
         });
 
         // Set static classes and remove transitions when animation ends
@@ -219,11 +219,11 @@ const AnimateHeight = class extends React.Component {
           // Hide content if height is 0 (to prevent tabbing into it)
           this.hideContent(timeoutState.height);
           // Run a callback if it exists
-          runCallback(onAnimationEnd);
+          runCallback(onAnimationEnd, { newHeight: timeoutState.height });
         }, totalDuration);
       } else {
         // ANIMATION STARTS, run a callback if it exists
-        runCallback(onAnimationStart);
+        runCallback(onAnimationStart, { newHeight });
 
         // Set end height, classes and remove transitions when animation is complete
         this.timeoutID = setTimeout(() => {
@@ -240,7 +240,7 @@ const AnimateHeight = class extends React.Component {
             this.hideContent(newHeight); // TODO solve newHeight = 0
           }
           // Run a callback if it exists
-          runCallback(onAnimationEnd);
+          runCallback(onAnimationEnd, { newHeight });
         }, totalDuration);
       }
     }


### PR DESCRIPTION
Implements https://github.com/Stanko/react-animate-height/issues/63

Passing an object rather than the raw value for better semantics in the callback and so the information passed in the callback could be easily extended later.

Adding to the onAnimationEnd callback done for symmetry and as a convenience even though it would be possible to just measure the height of the element at that point.