### PR TITLE
Adding opacity properties for delay, duration, and easing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,17 +89,29 @@ export default class Example extends Component {
   When changed, element height will be animated to that height.<br/>
   To slide up use <code>0</code>, for slide down use <code>'auto'</code>
 
-* **duration**: integer, default: `250`
-
-  Duration of the animation in milliseconds
-
 * **delay**: integer, default: `0`
 
   Animation delay in milliseconds
 
+* **duration**: integer, default: `250`
+
+  Duration of the animation in milliseconds
+
 * **easing**: string, default: `'ease'`
 
   CSS easing function to be applied to the animation
+
+* **opacityDelay**: integer, default: `0`
+
+  Animation delay for the opacity property in milliseconds, only active if `animateOpacity` is `true`. If this is not set, the value is taken from `delay`.
+
+* **opacityDuration**: integer, default: `250`
+
+  Duration of the animation for the opacity property in milliseconds, only active if `animateOpacity` is `true`. If this is not set, the value is taken from `duration`.
+
+* **opacityEasing**: string, default: `'ease'`
+
+  CSS easing function to be applied to the animation for the opacity property, only active if `animateOpacity` is `true`. If this is not set, the value is taken from `easing`.
 
 * **className**: string
 

--- a/source/AnimateHeight.js
+++ b/source/AnimateHeight.js
@@ -387,8 +387,8 @@ AnimateHeight.propTypes = {
   onAnimationEnd: PropTypes.func,
   onAnimationStart: PropTypes.func,
   opacityDelay: PropTypes.number,
-  opacityDuration: PropTypes.string,
-  opacityEasing: PropTypes.number,
+  opacityDuration: PropTypes.number,
+  opacityEasing: PropTypes.string,
   style: PropTypes.object,
 };
 

--- a/source/AnimateHeight.js
+++ b/source/AnimateHeight.js
@@ -27,6 +27,9 @@ const PROPS_TO_OMIT = [
   'height',
   'onAnimationEnd',
   'onAnimationStart',
+  'opacityDelay',
+  'opacityDuration',
+  'opacityEasing'
 ];
 
 function omit(obj, ...keys) {
@@ -121,6 +124,8 @@ const AnimateHeight = class extends React.Component {
       height,
       onAnimationEnd,
       onAnimationStart,
+      opacityDelay,
+      opacityDuration
     } = this.props;
 
     // Check if 'height' prop has changed
@@ -135,7 +140,7 @@ const AnimateHeight = class extends React.Component {
       this.contentElement.style.overflow = '';
 
       // set total animation time
-      const totalDuration = duration + delay;
+      const totalDuration = Math.max(duration + delay, opacityDuration + opacityDelay);
 
       let newHeight = null;
       const timeoutState = {
@@ -288,6 +293,9 @@ const AnimateHeight = class extends React.Component {
       duration,
       easing,
       delay,
+      opacityDelay,
+      opacityDuration,
+      opacityEasing,
       style,
     } = this.props;
     const {
@@ -305,11 +313,11 @@ const AnimateHeight = class extends React.Component {
     };
 
     if (shouldUseTransitions && applyInlineTransitions) {
-      componentStyle.transition = `height ${ duration }ms ${ easing } ${ delay }ms`;
+      componentStyle.transition = `height ${duration}ms ${easing} ${delay}ms`;
 
       // Include transition passed through styles
       if (style.transition) {
-        componentStyle.transition = `${ style.transition }, ${ componentStyle.transition }`;
+        componentStyle.transition = `${style.transition}, ${componentStyle.transition}`;
       }
 
       // Add webkit vendor prefix still used by opera, blackberry...
@@ -319,7 +327,7 @@ const AnimateHeight = class extends React.Component {
     const contentStyle = {};
 
     if (animateOpacity) {
-      contentStyle.transition = `opacity ${ duration }ms ${ easing } ${ delay }ms`;
+      contentStyle.transition = `opacity ${opacityDuration ? opacityDuration : duration}ms ${opacityEasing ? opacityEasing : easing} ${opacityDelay ? opacityDelay : delay}ms`;
       // Add webkit vendor prefix still used by opera, blackberry...
       contentStyle.WebkitTransition = contentStyle.transition;
 
@@ -335,17 +343,17 @@ const AnimateHeight = class extends React.Component {
 
     return (
       <div
-        { ...omit(this.props, ...PROPS_TO_OMIT) }
-        aria-hidden={ height === 0 }
-        className={ componentClasses }
-        style={ componentStyle }
+        {...omit(this.props, ...PROPS_TO_OMIT)}
+        aria-hidden={height === 0}
+        className={componentClasses}
+        style={componentStyle}
       >
         <div
-          className={ contentClassName }
-          style={ contentStyle }
-          ref={ el => this.contentElement = el }
+          className={contentClassName}
+          style={contentStyle}
+          ref={el => this.contentElement = el}
         >
-          { children }
+          {children}
         </div>
       </div>
     );
@@ -360,7 +368,7 @@ const heightPropType = (props, propName, componentName) => {
   }
 
   return new TypeError(
-    `value "${ value }" of type "${ typeof value }" is invalid type for ${ propName } in ${ componentName }. ` +
+    `value "${value}" of type "${typeof value}" is invalid type for ${propName} in ${componentName}. ` +
     'It needs to be a positive number, string "auto" or percentage string (e.g. "15%").'
   );
 };
@@ -372,12 +380,15 @@ AnimateHeight.propTypes = {
   children: PropTypes.any.isRequired,
   className: PropTypes.string,
   contentClassName: PropTypes.string,
-  duration: PropTypes.number,
   delay: PropTypes.number,
+  duration: PropTypes.number,
   easing: PropTypes.string,
   height: heightPropType,
   onAnimationEnd: PropTypes.func,
   onAnimationStart: PropTypes.func,
+  opacityDelay: PropTypes.number,
+  opacityDuration: PropTypes.string,
+  opacityEasing: PropTypes.number,
   style: PropTypes.object,
 };
 
@@ -385,9 +396,12 @@ AnimateHeight.defaultProps = {
   animateOpacity: false,
   animationStateClasses: ANIMATION_STATE_CLASSES,
   applyInlineTransitions: true,
-  duration: 250,
   delay: 0,
+  duration: 250,
   easing: 'ease',
+  opacityDelay: 0,
+  opacityDuration: 250,
+  opacityEasing: 'ease',
   style: {},
 };
 

--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -26,9 +26,12 @@ export interface AnimateHeightProps {
   height?: string | number;
   onAnimationEnd?(props: { newHeight: number }): void;
   onAnimationStart?(props: { newHeight: number }): void;
+  opacityDelay?: number;
+  opacityDuration?: number;
+  opacityEasing?: "ease" | "linear" | "ease-in" | "ease-out" | "ease-in-out" | string;
   style?: CSSProperties;
 }
 
-declare class AnimateHeight extends Component<AnimateHeightProps> {}
+declare class AnimateHeight extends Component<AnimateHeightProps> { }
 
 export default AnimateHeight;


### PR DESCRIPTION
Hey @Stanko - I think this is more what you're looking for.  I was not able to turn off the spacing between objects (`{` and `}`) in my editor.  I'm not quite sure of how to do that, but it seems to omit the space there is pretty standard.  Either way, I added delay, duration, and easing to the library for controlling opacity separately.  I also made sure that the `totalDuration` being calculated was accurate to the longest of the two animations, not the sum of all of them (which could give some undesired results).  :)

[Here is a CodeSandbox of the library](https://codesandbox.io/s/xenodochial-liskov-viny7?fontsize=14), which I had to manually embed since I can't push my changes to NPM, obviously.