### PR TITLE
Update auto-height example to disconnect ResizeObserver when unmounted

### DIFF
--- a/docs/auto-height.tsx
+++ b/docs/auto-height.tsx
@@ -11,6 +11,8 @@ const AutoHeight = ({ children, ...props }) => {
     });
 
     resizeObserver.observe(contentDiv.current);
+
+    return () => resizeObserver.disconnect()
   }, []);
 
   return (


### PR DESCRIPTION
Noticed this when looking into the examples.
Just to make sure that the cleanup is handled properly, when the component unmounts.
